### PR TITLE
feat(Settings): enable toggling the menu upon opening Settings page

### DIFF
--- a/src/AppHeader.js
+++ b/src/AppHeader.js
@@ -4,15 +4,15 @@ import profilePicUrl from "./static/welcome-back-james.png";
 import "./AppHeader.css";
 import "./AppHeaderMenu.css";
 
+const toggleMenu = (event) => {
+  const el = document.getElementById("hamburger-menu");
+  const menuElement = document.getElementById("client-menu");
+  el.classList.toggle("is-active");
+  menuElement.classList.toggle("change");
+};
+
 const AppHeader = ({ content }) => {
   let isActive = false;
-
-  const toggleMenu = (event) => {
-    const el = document.getElementById("hamburger-menu");
-    const menuElement = document.getElementById("client-menu");
-    el.classList.toggle("is-active");
-    menuElement.classList.toggle("change");
-  };
 
   return (
     <>
@@ -49,4 +49,5 @@ const AppHeader = ({ content }) => {
   );
 };
 
+export { toggleMenu };
 export default AppHeader;

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -1,13 +1,13 @@
-import React from 'react';
+import React from "react";
 import AppHeader from "../AppHeader";
-import Slider from './Settings/Slider.js';
-import { loadScript } from '../utils.js';
-import './Preview.css';
-import './Settings/Settings.css';
-import './Settings/Slider.css';
+import Slider from "./Settings/Slider.js";
+import { loadScript } from "../utils.js";
+import "./Preview.css";
+import "./Settings/Settings.css";
+import "./Settings/Slider.css";
 
 function Preview(props) {
-  const {color, size} = props.state
+  const { color, size } = props.state;
 
   return (
     <>
@@ -15,10 +15,14 @@ function Preview(props) {
       <div id="preview">
         <div className="container">
           <div className="path">
-            <span id="elem" className="shape circle trail" style={{backgroundColor: color}}></span>
+            <span
+              id="elem"
+              className="shape circle trail"
+              style={{ backgroundColor: color }}
+            ></span>
           </div>
         </div>
-      {loadScript("./SliderConfig.js")}
+        {loadScript("./SliderConfig.js")}
       </div>
     </>
   );

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -1,58 +1,57 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
-import AppHeader from "../../AppHeader";
-import Slider from './Slider.js';
-import { loadScript } from '../../utils.js';
-import './Settings.css';
-import './Slider.css';
+import AppHeader, { toggleMenu } from "../../AppHeader";
+import Slider from "./Slider.js";
+import { loadScript } from "../../utils.js";
+import "./Settings.css";
+import "./Slider.css";
 
-let lightElem = null
-const shapes = ['circle', 'square']
+let lightElem = null;
+const shapes = ["circle", "square"];
 
 // adds shape class to light element
 const changeShape = (elem, shape) => {
-  shapes.forEach(shape => elem.current.classList.remove(shape))
-  elem.current.classList.add(shape)
-}
+  shapes.forEach((shape) => elem.current.classList.remove(shape));
+  elem.current.classList.add(shape);
+};
 
 function SettingsMenu(props) {
-
   let lightSpeed = 2;
-  const {color, size} = props.state
-  const { updateSettings } = props
+  const { color, size } = props.state;
+  const { updateSettings } = props;
 
   const increaseSpeed = () => {
     let lightElem = document.getElementById("elem");
     if (lightSpeed > 1) {
       lightSpeed -= 1;
     }
-    lightElem.style = 'animation: ani ' + lightSpeed + 's infinite';
+    lightElem.style = "animation: ani " + lightSpeed + "s infinite";
   };
 
   const decreaseSpeed = () => {
     let lightElem = document.getElementById("elem");
     lightSpeed += 1;
-    lightElem.style = 'animation: ani ' + lightSpeed + 's infinite';
-  }
-  
+    lightElem.style = "animation: ani " + lightSpeed + "s infinite";
+  };
+
   // configures showing selection and what shape shoudl be set
   const onClickConfigure = (event) => {
     const el = event.target;
 
-    const shapes = el.parentNode.querySelectorAll('span')
-    shapes.forEach(item => {
-      item.classList.remove('selected')
+    const shapes = el.parentNode.querySelectorAll("span");
+    shapes.forEach((item) => {
+      item.classList.remove("selected");
     });
 
-    el.classList.add('selected');
-    const shape = el.getAttribute('data-shape')
-    changeShape(lightElem, shape)
-  }
+    el.classList.add("selected");
+    const shape = el.getAttribute("data-shape");
+    changeShape(lightElem, shape);
+  };
 
   const onClickColor = (event, update) => {
     onClickConfigure(event);
     updateSettings(update);
-  }
+  };
 
   return (
     <section id="settings">
@@ -61,18 +60,36 @@ function SettingsMenu(props) {
 
         <section className="configuration" id="shape">
           <h3>Shape</h3>
-          <span className="shape-circle selected" data-shape="circle" onClick={onClickConfigure}></span>
-          <span className="shape-square" data-shape="square" onClick={onClickConfigure}></span>
+          <span
+            className="shape-circle selected"
+            data-shape="circle"
+            onClick={onClickConfigure}
+          ></span>
+          <span
+            className="shape-square"
+            data-shape="square"
+            onClick={onClickConfigure}
+          ></span>
         </section>
 
         <section className="configuration" id="color">
           <h3>Color</h3>
-          <span className="shape-circle white selected" onClick={ e => { onClickColor(e, {color: '#fff'}) }}></span>
+          <span
+            className="shape-circle white selected"
+            onClick={(e) => {
+              onClickColor(e, { color: "#fff" });
+            }}
+          ></span>
           <span className="shape-circle grey"></span>
           <span className="shape-circle blue"></span>
           <span className="shape-circle yellow"></span>
           <span className="shape-circle green"></span>
-          <span className="shape-circle red" onClick={e => { onClickColor(e, {color: '#ff4848'}) }}></span>
+          <span
+            className="shape-circle red"
+            onClick={(e) => {
+              onClickColor(e, { color: "#ff4848" });
+            }}
+          ></span>
           <span className="shape-circle black"></span>
         </section>
 
@@ -95,13 +112,20 @@ function SettingsMenu(props) {
           <h3>Audio</h3>
           <div className="switch">
             <input type="checkbox" id="switch1" className="switch__input" />
-            <label htmlFor="switch1" className="switch__label" role="presentation" aria-label="Toggle Audio"></label>
+            <label
+              htmlFor="switch1"
+              className="switch__label"
+              role="presentation"
+              aria-label="Toggle Audio"
+            ></label>
           </div>
         </section>
 
         <section className="configuration" id="actions">
           <Link to="/preview">
-            <button id="preview-btn" className="btn">Preview</button>
+            <button id="preview-btn" className="btn">
+              Preview
+            </button>
           </Link>
         </section>
       </section>
@@ -111,22 +135,27 @@ function SettingsMenu(props) {
   );
 }
 
-
 // Settings component
 function Settings(props) {
-  const {color, size} = props.state
-  lightElem = useRef(null)
+  const { color, size } = props.state;
+  lightElem = useRef(null);
 
   useEffect(() => {
-    changeShape(lightElem, 'circle')
-  })
+    changeShape(lightElem, "circle");
+    toggleMenu();
+  });
 
   return (
     <>
-      <AppHeader  content={<SettingsMenu {...props}/>}/>
+      <AppHeader content={<SettingsMenu {...props} />} />
       <div className="container">
         <div className="path">
-          <span id="elem" ref={lightElem} className="shape trail" style={{backgroundColor: color}}></span>
+          <span
+            id="elem"
+            ref={lightElem}
+            className="shape trail"
+            style={{ backgroundColor: color }}
+          ></span>
         </div>
       </div>
     </>


### PR DESCRIPTION
# Overview
This exports the `toggleMenu` from `<AppHeader />` component so when visiting the Settings page it automatically opens the submenu from the header.

**note**: Other updates are just linting auto-formatting

<img width="1423" alt="Screen Shot 2020-06-19 at 6 41 56 PM" src="https://user-images.githubusercontent.com/1338412/85188592-cfb98a00-b25c-11ea-9fde-cb58eabdc5c8.png">
